### PR TITLE
Use user defined prompt colour variables.

### DIFF
--- a/fishfile
+++ b/fishfile
@@ -1,5 +1,4 @@
 git_util
-pwd_info
 pwd_is_home
 host_info
 last_job_id

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -14,11 +14,12 @@ function fish_prompt
     set_color normal
     
     if test 0 -eq (id -u $USER) -o ! -z "$SSH_CLIENT"
-        echo -sn (set_color $fish_color_user) (host_info "user")
+        echo -sn (set_color -o $fish_color_user) (host_info "user")
         echo -sn (set_color $fish_color_normal) "@"
-        echo -sn (set_color $fish_color_host) (host_info "host ")
+        echo -sn (set_color -o $fish_color_host) (host_info "host ")
     end
-
+    set_color normal 
+    
     switch $USER
         case root
         set_color $fish_color_cwd_root
@@ -30,7 +31,7 @@ function fish_prompt
     if set -l branch_name (git_branch_name)
         set -l git_glyph " on "
         set -l branch_glyph
-        # Using custom color since there isn't a defined vairbles for git stuff
+        # Using custom colours since there aren't defined variables for git stuff
         set -l branch_color 0fc -o
 
         if git_is_detached_head

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -1,11 +1,22 @@
 function fish_prompt
+    # If any of the colour variables aren't defined they're set to 'normal' colour 
+    for color in $fish_color_cwd $fish_color_cwd_root $fish_color_error $fish_color_host $fish_color_operator $fish_color_user
+        if set -q color
+            set color normal
+        end
+    end
+    
+    # Make a local copy of the status code of last command
     set -l status_copy $status
+    # Since there isn't a "official" colour variables for sucess colour, we've chose one. 
     set -l status_color 0fc
 
+    # If last command exited with an error change colour of the "Dartfish" in the prompt
     if test "$status_copy" -ne 0
         set status_color $fish_color_error
     end
 
+    # Change Dartfish symbol based on current location
     if pwd_is_home
         echo -sn (set_color -o $status_color) "⨉⪧ "
     else
@@ -13,6 +24,7 @@ function fish_prompt
     end
     set_color normal
     
+    # If running in root mode or connected to some other host, display relavent information
     if test 0 -eq (id -u $USER) -o ! -z "$SSH_CLIENT"
         echo -sn (set_color -o $fish_color_user) (host_info "user")
         echo -sn (set_color $fish_color_normal) "@"
@@ -20,6 +32,7 @@ function fish_prompt
     end
     set_color normal 
     
+    # Switch colour variables based on current user
     switch $USER
         case root
         set_color $fish_color_cwd_root
@@ -28,6 +41,7 @@ function fish_prompt
     end
     echo -sn (prompt_pwd)
     
+    # Git information if cwd is a git repo
     if set -l branch_name (git_branch_name)
         set -l git_glyph " on "
         set -l branch_glyph
@@ -71,6 +85,7 @@ function fish_prompt
         echo -sn (set_color fff) "$branch_glyph" (set_color normal)
     end
 
+    # Operator at the end to show the end of prompt, can be confusing without it sometimes
     set_color $fish_color_operator
     echo -ns " ⟩"
     set_color normal

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -1,42 +1,36 @@
 function fish_prompt
     set -l status_copy $status
     set -l status_color 0fc
-    set -l root_glyph
-    set -l pwd_info (pwd_info "/")
 
     if test "$status_copy" -ne 0
-        set status_color f30
+        set status_color $fish_color_error
     end
 
     if pwd_is_home
-        echo -sn (set_color -o $status_color) "⋊> " (set_color normal)
-        set root_glyph "~/"
+        echo -sn (set_color -o $status_color) "⨉⪧ "
     else
-        echo -sn (set_color -o $status_color) "⧕ " (set_color normal)
-        set root_glyph "/"
+        echo -sn (set_color -o $status_color) "⧕ "
     end
-
+    set_color normal
+    
     if test 0 -eq (id -u $USER) -o ! -z "$SSH_CLIENT"
-        echo -sn (set_color 0fc) (host_info "user@host ") (set_color normal)
+        echo -sn (set_color $fish_color_user) (host_info "user")
+        echo -sn (set_color $fish_color_normal) "@"
+        echo -sn (set_color $fish_color_host) (host_info "host ")
     end
 
-    echo -sn (set_color cff) $root_glyph (set_color normal)
-
-    if test ! -z "$pwd_info[2]"
-        echo -sn (set_color cff) "$pwd_info[2]/" (set_color normal)
+    switch $USER
+        case root
+        set_color $fish_color_cwd_root
+        case "*"
+        set_color $fish_color_cwd
     end
-
-    if test ! -z "$pwd_info[1]"
-        echo -sn (set_color 0fc) "$pwd_info[1]" (set_color normal)
-    end
-
-    if test ! -z "$pwd_info[3]"
-        echo -sn (set_color cff) "/$pwd_info[3]" (set_color normal)
-    end
-
+    echo -sn (prompt_pwd)
+    
     if set -l branch_name (git_branch_name)
         set -l git_glyph " on "
         set -l branch_glyph
+        # Using custom color since there isn't a defined vairbles for git stuff
         set -l branch_color 0fc -o
 
         if git_is_detached_head
@@ -76,5 +70,7 @@ function fish_prompt
         echo -sn (set_color fff) "$branch_glyph" (set_color normal)
     end
 
-    echo " "
+    set_color $fish_color_operator
+    echo -ns " ⟩"
+    set_color normal
 end

--- a/functions/fish_right_prompt.fish
+++ b/functions/fish_right_prompt.fish
@@ -1,4 +1,10 @@
 function fish_right_prompt
+    # If any of the colour variables aren't defined they're set to 'normal' colour 
+    for color in $fish_color_error
+        if set -q color
+            set color normal
+        end
+    end
     set -l status_copy $status
     set -l status_color 0fc
 

--- a/functions/fish_right_prompt.fish
+++ b/functions/fish_right_prompt.fish
@@ -3,7 +3,7 @@ function fish_right_prompt
     set -l status_color 0fc
 
     if test "$status_copy" -ne 0
-        set status_color f30
+        set status_color $fish_color_error
     end
 
     if test "$CMD_DURATION" -gt 100


### PR DESCRIPTION
Changes:
- Using colour variables where possible.
- Also changed the dart fish symbol slightly. From `⋊>` to `⨉⪧`, now it works with other fonts e.g. monofer.
- Added an operator at the end of the prompt.

@bucaran Any feedback? Best to try it out to see the results. One problem I encountered was that one of the colour variables wasn't defined so it gave an error when setting that colour. Should we look into this? In my case it was `fish_color_host`. The error was `set_color: Unknown color ''` perhaps just include it in the README.

Since we're not gonna use the custom colours, should I remove the `set_color_custom.fish`?